### PR TITLE
Fixed build error for Unreal 4.26

### DIFF
--- a/Source/TextAssetEditor/Private/Styles/TextAssetEditorStyle.h
+++ b/Source/TextAssetEditor/Private/Styles/TextAssetEditorStyle.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "IPluginManager.h"
+#include "Interfaces/IPluginManager.h"
 #include "Brushes/SlateImageBrush.h"
 #include "Styling/SlateStyle.h"
 #include "Styling/SlateStyleRegistry.h"


### PR DESCRIPTION
Modify #include "IPluginManager.h" to #include "Interfaces/IPluginManager.h" for build on UE4.26